### PR TITLE
fix: Jellyfin 10.11+ compatibility

### DIFF
--- a/Jellyfin.Plugin.ProviderStuff/Api/ProvidersController.cs
+++ b/Jellyfin.Plugin.ProviderStuff/Api/ProvidersController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.ProviderStuff.Configuration;
+using Jellyfin.Plugin.ProviderStuff.Library;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
@@ -59,13 +60,13 @@ public class ProvidersController : ControllerBase
                 string collectionId = string.Empty;
                 if (p.CreateCollection)
                 {
-                    var items = _libraryManager.GetItemList(new InternalItemsQuery
+                    var items = _libraryManager.GetItemsList(new InternalItemsQuery
                     {
                         IncludeItemTypes = new[] { BaseItemKind.BoxSet },
                         Name = p.Name,
                         Recursive = true
                     });
-                    var existing = items.FirstOrDefault();
+                    var existing = items.Count > 0 ? items[0] : null;
                     if (existing is not null)
                     {
                         collectionId = existing.Id.ToString();
@@ -122,7 +123,7 @@ public class ProvidersController : ControllerBase
         };
 
         // Get total count (could be optimized with dedicated count API if available)
-        var totalItems = _libraryManager.GetItemList(baseQuery);
+        var totalItems = _libraryManager.GetItemsList(baseQuery);
         var total = totalItems.Count;
 
         // Page query
@@ -135,7 +136,7 @@ public class ProvidersController : ControllerBase
             Limit = limit is > 0 ? limit : null
         };
 
-        var pageItems = _libraryManager.GetItemList(query);
+        var pageItems = _libraryManager.GetItemsList(query);
         var user = userId.HasValue ? _userManager.GetUserById(userId.Value) : null;
         var dtos = _dtoService.GetBaseItemDtos(pageItems, new DtoOptions(), user).ToArray();
         var result = new QueryResult<BaseItemDto>

--- a/Jellyfin.Plugin.ProviderStuff/Library/LibraryManagerExtensions.cs
+++ b/Jellyfin.Plugin.ProviderStuff/Library/LibraryManagerExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.ProviderStuff.Library;
+
+/// <summary>
+/// Jellyfin 10.11 changed ILibraryManager.GetItemList(InternalItemsQuery) to return
+/// IReadOnlyList instead of List. Direct calls compiled against 10.9 packages fail at runtime on 10.11+.
+/// </summary>
+internal static class LibraryManagerExtensions
+{
+    private static readonly MethodInfo GetItemListMethod = typeof(ILibraryManager).GetMethod(
+        nameof(ILibraryManager.GetItemList),
+        BindingFlags.Public | BindingFlags.Instance,
+        binder: null,
+        types: new[] { typeof(InternalItemsQuery) },
+        modifiers: null)
+        ?? throw new InvalidOperationException("ILibraryManager.GetItemList(InternalItemsQuery) was not found.");
+
+    /// <summary>
+    /// Returns library items for a query, compatible with Jellyfin 10.9 and 10.11+.
+    /// </summary>
+    /// <param name="libraryManager">Library manager instance.</param>
+    /// <param name="query">Item query.</param>
+    /// <returns>Matching items.</returns>
+    public static IReadOnlyList<BaseItem> GetItemsList(this ILibraryManager libraryManager, InternalItemsQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(libraryManager);
+        ArgumentNullException.ThrowIfNull(query);
+
+        var result = GetItemListMethod.Invoke(libraryManager, new object[] { query });
+        return result switch
+        {
+            null => Array.Empty<BaseItem>(),
+            List<BaseItem> list => list,
+            IReadOnlyList<BaseItem> readOnly => readOnly,
+            IEnumerable<BaseItem> enumerable => enumerable.ToList(),
+            _ => throw new InvalidOperationException(
+                $"Unexpected return type from GetItemList: {result.GetType().FullName}")
+        };
+    }
+}

--- a/Jellyfin.Plugin.ProviderStuff/ScheduledTasks/ApplyProviderTagsTask.cs
+++ b/Jellyfin.Plugin.ProviderStuff/ScheduledTasks/ApplyProviderTagsTask.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.ProviderStuff.Configuration;
+using Jellyfin.Plugin.ProviderStuff.Library;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Entities;
@@ -24,6 +25,7 @@ namespace Jellyfin.Plugin.ProviderStuff.ScheduledTasks;
 public class ApplyProviderTagsTask : IScheduledTask, IConfigurableScheduledTask
 {
     private readonly ILibraryManager _libraryManager;
+    private readonly IProviderManager _providerManager;
     private readonly ILogger<ApplyProviderTagsTask> _logger;
     private readonly ProviderService _providerService;
     private readonly IConfigurationManager _config;
@@ -36,10 +38,12 @@ public class ApplyProviderTagsTask : IScheduledTask, IConfigurableScheduledTask
     /// <param name="logger">The logger to record diagnostic and error messages.</param>
     /// <param name="providerService">The service used to fetch provider IDs from TMDB.</param>
     /// <param name="config">The configuration manager to access plugin settings.</param>
+    /// <param name="providerManager">Downloads and saves remote images.</param>
     /// <param name="collectionManager">The collection manager for creating and updating collections.</param>
-    public ApplyProviderTagsTask(ILibraryManager libraryManager, ILogger<ApplyProviderTagsTask> logger, ProviderService providerService, IConfigurationManager config, ICollectionManager collectionManager)
+    public ApplyProviderTagsTask(ILibraryManager libraryManager, IProviderManager providerManager, ILogger<ApplyProviderTagsTask> logger, ProviderService providerService, IConfigurationManager config, ICollectionManager collectionManager)
     {
         _libraryManager = libraryManager;
+        _providerManager = providerManager;
         _logger = logger;
         _providerService = providerService;
         _config = config;
@@ -117,7 +121,7 @@ public class ApplyProviderTagsTask : IScheduledTask, IConfigurableScheduledTask
             foreach (var provider in providersNeedingCollections)
             {
                 var collectionName = provider.Name;
-                var collections = _libraryManager.GetItemList(new InternalItemsQuery
+                var collections = _libraryManager.GetItemsList(new InternalItemsQuery
                 {
                     IncludeItemTypes = new[] { BaseItemKind.BoxSet },
                     Name = collectionName,
@@ -160,7 +164,7 @@ public class ApplyProviderTagsTask : IScheduledTask, IConfigurableScheduledTask
             }
         }
 
-        var items = _libraryManager.GetItemList(new InternalItemsQuery
+        var items = _libraryManager.GetItemsList(new InternalItemsQuery
         {
             IncludeItemTypes = new[] { BaseItemKind.Movie, BaseItemKind.Series, BaseItemKind.Episode },
             Recursive = true
@@ -235,32 +239,25 @@ public class ApplyProviderTagsTask : IScheduledTask, IConfigurableScheduledTask
         }
 
         var url = provider.ProviderLogoUrl.Trim();
-        _logger.LogInformation("Setting primary image for collection '{Name}' from {Url}", collection.Name, url);
-
-        // Add as remote image first
-        var remoteImage = new ItemImageInfo
+        if (!Uri.TryCreate(url, UriKind.Absolute, out _))
         {
-            Path = url,
-            Type = ImageType.Primary,
-            DateModified = DateTime.UtcNow
-        };
+            _logger.LogWarning("Provider logo URL for '{Name}' is not absolute, skipping image: {Url}", collection.Name, url);
+            return;
+        }
 
-        collection.AddImage(remoteImage);
-
-        // Persist image info
-        await _libraryManager.UpdateItemAsync(collection, collection, ItemUpdateType.ImageUpdate, ct).ConfigureAwait(false);
+        _logger.LogInformation("Setting primary image for collection '{Name}' from {Url}", collection.Name, url);
 
         try
         {
-            // Convert to local so it survives and benefits from caching/processing
-            var index = collection.GetImageIndex(remoteImage);
-            await _libraryManager.ConvertImageToLocal(collection, remoteImage, index, removeOnFailure: true).ConfigureAwait(false);
+            // SaveImage downloads directly; ConvertImageToLocal fails on 10.11+ after UpdateItemAsync
+            // because ItemImageInfo.Path is no longer the remote URL.
+            await _providerManager.SaveImage(collection, url, ImageType.Primary, 0, ct).ConfigureAwait(false);
             await _libraryManager.UpdateImagesAsync(collection, forceUpdate: true).ConfigureAwait(false);
             _logger.LogInformation("Primary image set for collection '{Name}'", collection.Name);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to convert image to local for collection '{Name}'", collection.Name);
+            _logger.LogError(ex, "Failed to download collection image for '{Name}'", collection.Name);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes ProviderStuff on Jellyfin **10.11+**:

1. **Scheduled task / API queries** — `ILibraryManager.GetItemList` now returns `IReadOnlyList<BaseItem>` instead of `List<BaseItem>`, which caused `MissingMethodException` for plugins built against the 10.9 SDK.
2. **Collection logos** — `ConvertImageToLocal` failed after `UpdateItemAsync` because `ItemImageInfo.Path` was no longer the remote URL (`InvalidOperationException: invalid request URI`).

## Changes

- Add `LibraryManagerExtensions.GetItemsList` (reflection, compatible with 10.9 and 10.11+)
- Use `GetItemsList` in `ApplyProviderTagsTask` and `ProvidersController`
- Inject `IProviderManager` and download collection images via `SaveImage`

## Testing

Tested and working on Jellyfin **10.11.10** (scheduled task, provider collections with logos, catalog install).

Closes #6