### PR TITLE
fix: correct assembly version and manifest guid

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.0.0</Version>
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
-        <FileVersion>0.0.0.0</FileVersion>
+        <Version>1.2.0.0</Version>
+        <AssemblyVersion>1.2.0.0</AssemblyVersion>
+        <FileVersion>1.2.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 ---
 name: "ProviderStuff"
-guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
+guid: "7cedceba-76f2-40dd-a902-b05acf337a57"
 version: "1.1.0.0"
 targetAbi: "10.9.0.0"
 framework: "net8.0"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "ProviderStuff",
-        "guid": "eb5d7894-8eef-4b36-aa6f-5d124e828ce1",
+        "guid": "7cedceba-76f2-40dd-a902-b05acf337a57",
         "version": "1.1.0.0",
         "targetAbi": "10.9.0.0",
         "framework": "net8.0",


### PR DESCRIPTION
## Summary
- Set `Directory.Build.props` to **1.2.0.0** instead of `0.0.0.0` so installed plugins report the correct version
- Align `manifest.json` and `build.yaml` `guid` with `Plugin.Id` (`7cedceba-76f2-40dd-a902-b05acf337a57`)
## Problem
Jellyfin shows `Loaded plugin: ProviderStuff 0.0.0.0` and the plugin details page reports *"An error occurred while getting the plugin details from the repository"* because the catalog `guid` did not match the assembly id and the DLL version did not match the published release.
Fixes #5